### PR TITLE
Update getting_started_with_lava.html

### DIFF
--- a/getting_started_with_lava.html
+++ b/getting_started_with_lava.html
@@ -171,13 +171,13 @@
 <div class="section" id="fundamental-concepts">
 <h2>Fundamental concepts:<a class="headerlink" href="#fundamental-concepts" title="Permalink to this headline"></a></h2>
 <p>These tutorials walk step-by-step through the fundamental concepts of Lava introduced in <a class="reference external" href="https://lava-nc.org/lava_architecture_overview.html">Lava Architecture</a>. These tutorials tend to build on each other, therefore it’s best to consume them in order.</p>
-<p>1. <a class="reference external" href="https://github.com/lava-nc/lava/blob/main/lava/tutorials/in_depth/tutorial01_installing_lava.ipynb">Installing Lava</a>:
+<p>1. <a class="reference external" href="https://github.com/lava-nc/lava/blob/main/src/lava/tutorials/in_depth/tutorial01_installing_lava.ipynb">Installing Lava</a>:
 Quickly get Lava installed, tested and ready to develop on your system.</p>
-<p>2. <a class="reference external" href="https://github.com/lava-nc/lava/blob/main/lava/tutorials/in_depth/tutorial02_processes.ipynb">Processes</a>:
+<p>2. <a class="reference external" href="https://github.com/lava-nc/lava/blob/main/src/lava/tutorials/in_depth/tutorial02_processes.ipynb">Processes</a>:
 Learn how to create <em>Processes</em> which are Lava’s fundamental computational building blocks.</p>
-<p>3. <a class="reference external" href="https://github.com/lava-nc/lava/blob/main/lava/tutorials/in_depth/tutorial03_process_models.ipynb">Process models</a>:
+<p>3. <a class="reference external" href="https://github.com/lava-nc/lava/blob/main/src/lava/tutorials/in_depth/tutorial03_process_models.ipynb">Process models</a>:
 Learn to implement <em>Process</em> behavior with the ability to run on diverse backends via Lava <em>ProcessModels</em>.</p>
-<p>4. <a class="reference external" href="https://github.com/lava-nc/lava/blob/main/lava/tutorials/in_depth/tutorial04_execution.ipynb">Execution</a>:
+<p>4. <a class="reference external" href="https://github.com/lava-nc/lava/blob/main/src/lava/tutorials/in_depth/tutorial04_execution.ipynb">Execution</a>:
 This notebook demonstrates how to configure, start, and stop the execution of a network of <em>Processes</em>.</p>
 <p><strong>Coming shortly:</strong></p>
 <p>5. Connecting processes:


### PR DESCRIPTION
Updated paths to tutorials after the directory restructure of core lava repo.
Fixes #1 